### PR TITLE
Simplify type annotations by removing redundant `TypeVar` declarations

### DIFF
--- a/curlifier/builders/base.py
+++ b/curlifier/builders/base.py
@@ -1,7 +1,4 @@
 from abc import ABC, abstractmethod
-from typing import TypeVar
-
-SelfBuilder = TypeVar('SelfBuilder', bound='Builder')
 
 
 class Builder(ABC):
@@ -10,10 +7,10 @@ class Builder(ABC):
     __slots__ = ()
 
     @abstractmethod
-    def build(self: SelfBuilder) -> str:
+    def build(self) -> str:
         """Assembles the result string that is part of the `curl` command."""
 
     @property
     @abstractmethod
-    def build_short(self: SelfBuilder) -> bool:
+    def build_short(self) -> bool:
         """Specify `True` if you want a short command."""

--- a/curlifier/builders/configurator.py
+++ b/curlifier/builders/configurator.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, ClassVar, TypeAlias, TypeVar
+from typing import TYPE_CHECKING, ClassVar, TypeAlias
 
 from curlifier.builders.base import Builder
 from curlifier.structures.commands import (
@@ -9,9 +9,6 @@ from curlifier.structures.commands import (
 
 if TYPE_CHECKING:  # pragma: no cover
     from collections.abc import Generator
-
-SelfConfig = TypeVar('SelfConfig', bound='Config')
-SelfConfigBuilder = TypeVar('SelfConfigBuilder', bound='ConfigBuilder')
 
 CommandMapping: TypeAlias = tuple[tuple[CurlCommandTitle, CommandsConfigureEnum], ...]
 

--- a/curlifier/builders/curl.py
+++ b/curlifier/builders/curl.py
@@ -1,12 +1,10 @@
-from typing import ClassVar, TypeVar
+from typing import ClassVar
 
 from requests.models import PreparedRequest, Response
 
 from curlifier.builders.base import Builder
 from curlifier.builders.configurator import ConfigBuilder
 from curlifier.builders.transmitter import TransmitterBuilder
-
-SelfCurlBuilder = TypeVar('SelfCurlBuilder', bound='CurlBuilder')
 
 
 class CurlBuilder(Builder):

--- a/curlifier/builders/transmitter.py
+++ b/curlifier/builders/transmitter.py
@@ -1,6 +1,6 @@
 import copy
 import re
-from typing import Any, ClassVar, Literal, TypeAlias, TypeVar
+from typing import Any, ClassVar, Literal, TypeAlias
 
 from requests import PreparedRequest, Response
 from requests.structures import CaseInsensitiveDict
@@ -19,10 +19,6 @@ PreReqHttpHeaders: TypeAlias = CaseInsensitiveDict[str]
 PreReqHttpUrl: TypeAlias = str | Any | None
 FileNameWithExtension: TypeAlias = str
 FileFieldName: TypeAlias = str
-
-SelfDecoder = TypeVar('SelfDecoder', bound='Decoder')
-SelfPreparedTransmitter = TypeVar('SelfPreparedTransmitter', bound='PreparedTransmitter')
-SelfTransmitterBuilder = TypeVar('SelfTransmitterBuilder', bound='TransmitterBuilder')
 
 
 class Decoder:

--- a/curlifier/structures/commands.py
+++ b/curlifier/structures/commands.py
@@ -1,12 +1,10 @@
 import enum
-from typing import TypeAlias, TypeVar
+from typing import TypeAlias
 
 CurlCommandShort: TypeAlias = str
 CurlCommandLong: TypeAlias = str
 CurlCommand: TypeAlias = CurlCommandShort | CurlCommandLong
 CurlCommandTitle: TypeAlias = str
-
-SelfCommandsEnums = TypeVar('SelfCommandsEnums', bound='CommandsEnum')
 
 
 class CommandsEnum(enum.Enum):


### PR DESCRIPTION
This MR removes unnecessary TypeVar declarations used for self-type annotations across the codebase