### PR TITLE
Refactor parameter naming and improve code structure

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-# === Сonfiguration ===
+# === Configuration ===
 MAKEFLAGS += --silent
 make:
 	cat -n ./Makefile
@@ -27,6 +27,10 @@ test:
 .PHONY: cov-report
 cov-report:
 	poetry run pytest ./tests --cov=curlifier --cov-report=html
+
+.PHONY: cspell
+cspell:
+	npx cspell-cli --gitignore .
 
 # === Aliases ===
 pc: pre-commit

--- a/Makefile
+++ b/Makefile
@@ -28,11 +28,6 @@ test:
 cov-report:
 	poetry run pytest ./tests --cov=curlifier --cov-report=html
 
-.PHONY:
-all:
-	make lint && make test
-
 # === Aliases ===
 pc: pre-commit
 t: test
-a: all

--- a/Makefile
+++ b/Makefile
@@ -4,21 +4,35 @@ make:
 	cat -n ./Makefile
 
 # === Dev ===
+.PHONY: lint
 lint:
 	poetry run ruff check ./curlifier ./tests \
 	&& poetry run ruff format ./curlifier ./tests \
 	&& poetry run flake8 ./curlifier \
 	&& poetry run mypy ./curlifier --no-pretty
+
+.PHONY: pre-commit
 pre-commit:
 	make lint \
 	&& make test
+
+.PHONY: test-collect
 test-collect:
 	poetry run pytest ./tests/ --collect-only
+
+.PHONY: test
 test:
-	poetry run pytest ./tests/ 
+	poetry run pytest ./tests/
+
+.PHONY: cov-report
 cov-report:
 	poetry run pytest ./tests --cov=curlifier --cov-report=html
+
+.PHONY:
+all:
+	make lint && make tests
 
 # === Aliases ===
 pc: pre-commit
 t: test
+a: all

--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ cov-report:
 
 .PHONY:
 all:
-	make lint && make tests
+	make lint && make test
 
 # === Aliases ===
 pc: pre-commit

--- a/curlifier/api.py
+++ b/curlifier/api.py
@@ -49,7 +49,7 @@ def curlify(
     curl_builder = CurlBuilder(
         response=response,
         prepared_request=prepared_request,
-        build_short=shorted,
+        shorted=shorted,
         location=config.pop('location', False),
         verbose=config.pop('verbose', False),
         silent=config.pop('silent', False),

--- a/curlifier/api.py
+++ b/curlifier/api.py
@@ -56,6 +56,5 @@ def curlify(
         insecure=config.pop('insecure', False),
         include=config.pop('include', False),
     )
-    curl: str = curl_builder.build()
 
-    return curl
+    return curl_builder.build()

--- a/curlifier/builders/base.py
+++ b/curlifier/builders/base.py
@@ -12,5 +12,5 @@ class Builder(ABC):
 
     @property
     @abstractmethod
-    def build_short(self) -> bool:
+    def shorted(self) -> bool:
         """Specify `True` if you want a short command."""

--- a/curlifier/builders/configurator.py
+++ b/curlifier/builders/configurator.py
@@ -77,21 +77,21 @@ class Config:
 class ConfigBuilder(Config, Builder):
     """Builds a curl command configuration line."""
 
-    __slots__ = ('_build_short',)
+    __slots__ = ('_shorted',)
 
     def __init__(
         self,
         *,
-        build_short: bool = False,
+        shorted: bool,
         **config: bool,
     ) -> None:
-        self._build_short = build_short
+        self._shorted = shorted
         super().__init__(**config)
 
     def build(self) -> str:
         """Collects all parameters into the resulting string.
 
-        If `build_short` is `True` will be collected short version.
+        If `shorted` is `True` will be collected short version.
 
         >>> from curlifier.configurator import ConfigBuilder
         >>> conf = ConfigBuilder(
@@ -100,7 +100,7 @@ class ConfigBuilder(Config, Builder):
             silent=False,
             insecure=True,
             include=False,
-            build_short=False,
+            shorted=False,
         )
         >>> conf.build()
         '--location --verbose --insecure'
@@ -108,7 +108,7 @@ class ConfigBuilder(Config, Builder):
         command_parts = []
         for prop_name, command_enum in self.command_mapping:
             if getattr(self, prop_name):
-                command = command_enum.get(shorted=self.build_short)
+                command = command_enum.get(shorted=self.shorted)
                 command_parts.append(command)
 
         cleaned_commands: Generator[CurlCommand, None, None] = (command for command in command_parts if command)
@@ -116,10 +116,10 @@ class ConfigBuilder(Config, Builder):
         return ' '.join(cleaned_commands)
 
     @property
-    def build_short(self) -> bool:
+    def shorted(self) -> bool:
         """Controlling the form of command.
 
         :return: `True` and command will be short. Otherwise `False`.
         :rtype: bool
         """
-        return self._build_short
+        return self._shorted

--- a/curlifier/builders/curl.py
+++ b/curlifier/builders/curl.py
@@ -20,13 +20,13 @@ class CurlBuilder(Builder):
         silent: bool,
         insecure: bool,
         include: bool,
-        build_short: bool,
+        shorted: bool,
         response: Response | None = None,
         prepared_request: PreparedRequest | None = None,
     ) -> None:
-        self._build_short = build_short
+        self._shorted = shorted
         self.config = ConfigBuilder(
-            build_short=self._build_short,
+            shorted=self._shorted,
             location=location,
             verbose=verbose,
             silent=silent,
@@ -36,13 +36,13 @@ class CurlBuilder(Builder):
         self.transmitter = TransmitterBuilder(
             response=response,
             prepared_request=prepared_request,
-            build_short=self._build_short,
+            shorted=self._shorted,
         )
 
     def build(self) -> str:
         """Collects all parameters into the resulting string.
 
-        If `build_short` is `True` will be collected short version.
+        If `shorted` is `True` will be collected short version.
 
         >>> from curlifier.curl import CurlBuilder
         >>> import requests
@@ -50,7 +50,7 @@ class CurlBuilder(Builder):
         >>> curl_builder = CurlBuilder(
             response=r,
             location=True,
-            build_short=True,
+            shorted=True,
             verbose=False,
             silent=False,
             insecure=False,
@@ -68,10 +68,10 @@ class CurlBuilder(Builder):
         )
 
     @property
-    def build_short(self) -> bool:
+    def shorted(self) -> bool:
         """Controlling the form of command.
 
         :return: `True` and command will be short. Otherwise `False`.
         :rtype: bool
         """
-        return self._build_short
+        return self._shorted

--- a/curlifier/builders/curl.py
+++ b/curlifier/builders/curl.py
@@ -12,7 +12,7 @@ class CurlBuilder(Builder):
 
     curl_command: ClassVar[str] = 'curl'
 
-    def __init__(  # noqa: WPS211
+    def __init__(
         self,
         *,
         response: Response | None = None,

--- a/curlifier/builders/curl.py
+++ b/curlifier/builders/curl.py
@@ -12,26 +12,21 @@ class CurlBuilder(Builder):
 
     curl_command: ClassVar[str] = 'curl'
 
-    def __init__(  # noqa: PLR0913, WPS211
+    def __init__(  # noqa: WPS211
         self,
         *,
-        location: bool,
-        verbose: bool,
-        silent: bool,
-        insecure: bool,
-        include: bool,
-        shorted: bool,
         response: Response | None = None,
         prepared_request: PreparedRequest | None = None,
+        **config: bool,
     ) -> None:
-        self._shorted = shorted
+        self._shorted = config.pop('shorted')
         self.config = ConfigBuilder(
             shorted=self._shorted,
-            location=location,
-            verbose=verbose,
-            silent=silent,
-            insecure=insecure,
-            include=include,
+            location=config.pop('location'),
+            verbose=config.pop('verbose'),
+            silent=config.pop('silent'),
+            insecure=config.pop('insecure'),
+            include=config.pop('include'),
         )
         self.transmitter = TransmitterBuilder(
             response=response,

--- a/curlifier/builders/transmitter.py
+++ b/curlifier/builders/transmitter.py
@@ -24,6 +24,8 @@ FileFieldName: TypeAlias = str
 class Decoder:
     """Decodes the raw body of the request."""
 
+    __slots__ = ()
+
     def decode(
         self,
         data_for_decode: bytes | str,
@@ -83,10 +85,18 @@ class PreparedTransmitter:
     The original object will not be modified.
     """
 
+    __slots__ = (
+        '_body',
+        '_headers',
+        '_method',
+        '_pre_req',
+        '_response',
+        '_url',
+    )
+
     def __init__(
         self,
         response: Response | None = None,
-        *,
         prepared_request: PreparedRequest | None = None,
     ) -> None:
         if sum(arg is not None for arg in (response, prepared_request)) != 1:
@@ -141,6 +151,8 @@ class PreparedTransmitter:
 class TransmitterBuilder(PreparedTransmitter, Decoder, Builder):
     """Builds a curl command transfer part."""
 
+    __slots__ = ('_shorted',)
+
     built: ClassVar[ExecutableTemplate] = "{request_command} {method} '{url}' {request_headers} {request_data}"
     """The template of the resulting executable command."""
 
@@ -155,9 +167,9 @@ class TransmitterBuilder(PreparedTransmitter, Decoder, Builder):
 
     def __init__(
         self,
+        response: Response | None = None,
         *,
         shorted: bool,
-        response: Response | None = None,
         prepared_request: PreparedRequest | None = None,
     ) -> None:
         self._shorted = shorted

--- a/curlifier/builders/transmitter.py
+++ b/curlifier/builders/transmitter.py
@@ -91,10 +91,12 @@ class PreparedTransmitter:
     ) -> None:
         if sum(arg is not None for arg in (response, prepared_request)) != 1:
             raise MutuallyExclusiveArgsError(response, prepared_request)
+
+        self._response = response
         self._pre_req: PreparedRequest = (
             prepared_request.copy()  # type: ignore [union-attr]
-            if response is None
-            else response.request.copy()
+            if self._response is None
+            else self._response.request.copy()
         )
 
         self._method: PreReqHttpMethod = self._pre_req.method
@@ -154,26 +156,26 @@ class TransmitterBuilder(PreparedTransmitter, Decoder, Builder):
     def __init__(
         self,
         *,
-        build_short: bool,
+        shorted: bool,
         response: Response | None = None,
         prepared_request: PreparedRequest | None = None,
     ) -> None:
-        self._build_short = build_short
+        self._shorted = shorted
         super().__init__(response, prepared_request=prepared_request)
 
     def build(self) -> str:
         """Collects all parameters into the resulting string.
 
-        If `build_short` is `True` will be collected short version.
+        If `shorted` is `True` will be collected short version.
 
         >>> from curlifier.transmitter import TransmitterBuilder
         >>> import requests
         >>> r = requests.get('https://example.com/')
-        >>> t = TransmitterBuilder(response=r, build_short=False)
+        >>> t = TransmitterBuilder(response=r, shorted=False)
         >>> t.build()
         "--request GET 'https://example.com/' --header 'User-Agent: python-requests/2.32.3' <...>"
         """
-        request_command = CommandsTransferEnum.REQUEST.get(shorted=self.build_short)
+        request_command = CommandsTransferEnum.REQUEST.get(shorted=self._shorted)
         request_headers = self._build_executable_headers()
         request_data = self._build_executable_data()
 
@@ -186,18 +188,18 @@ class TransmitterBuilder(PreparedTransmitter, Decoder, Builder):
         )
 
     @property
-    def build_short(self) -> bool:
+    def shorted(self) -> bool:
         """Controlling the form of command.
 
         :return: `True` and command will be short. Otherwise `False`.
         :rtype: bool
         """
-        return self._build_short
+        return self._shorted
 
     def _build_executable_headers(self) -> str:
         return ' '.join(
             self.header.format(
-                command=CommandsTransferEnum.HEADER.get(shorted=self.build_short),
+                command=CommandsTransferEnum.HEADER.get(shorted=self._shorted),
                 key=header_key,
                 value=header_value,
             )
@@ -211,13 +213,13 @@ class TransmitterBuilder(PreparedTransmitter, Decoder, Builder):
             decode_body = self.decode(self.body)  # type: ignore [arg-type]
             if isinstance(decode_body, str):
                 return self.request_data.format(
-                    command=CommandsTransferEnum.SEND_DATA.get(shorted=self.build_short),
+                    command=CommandsTransferEnum.SEND_DATA.get(shorted=self._shorted),
                     request_data=decode_body,
                 )
             if isinstance(decode_body, tuple):
                 executable_files: str = ' '.join(
                     self.request_file.format(
-                        command=CommandsTransferEnum.FORM.get(shorted=self.build_short),
+                        command=CommandsTransferEnum.FORM.get(shorted=self._shorted),
                         field_name=field_name,
                         file_name=file_name,
                     )

--- a/curlifier/structures/commands.py
+++ b/curlifier/structures/commands.py
@@ -7,7 +7,7 @@ CurlCommand: TypeAlias = CurlCommandShort | CurlCommandLong
 CurlCommandTitle: TypeAlias = str
 
 
-class CommandsEnum(enum.Enum):
+class CurlCommandsEnum(enum.Enum):
     """Base class of the command curl structure.
 
     When initialized, it will take three values: title, short and long.
@@ -51,7 +51,7 @@ class CommandsEnum(enum.Enum):
 
 
 @enum.unique
-class CommandsConfigureEnum(CommandsEnum):
+class CommandsConfigureEnum(CurlCommandsEnum):
     """Curl configuration commands."""
 
     VERBOSE = '-v', '--verbose', 'verbose'
@@ -71,7 +71,7 @@ class CommandsConfigureEnum(CommandsEnum):
 
 
 @enum.unique
-class CommandsTransferEnum(CommandsEnum):
+class CommandsTransferEnum(CurlCommandsEnum):
     """Curl transfer commands."""
 
     SEND_DATA = '-d', '--data', 'data'

--- a/curlifier/structures/http_methods.py
+++ b/curlifier/structures/http_methods.py
@@ -17,7 +17,7 @@ class HttpMethodsEnum(enum.Enum):
     DELETE = 'DELETE'
 
     @classmethod
-    def get_methods_without_body(cls: type['HttpMethodsEnum']) -> tuple[HttpMethod, HttpMethod, HttpMethod, HttpMethod]:
+    def get_methods_without_body(cls: type['HttpMethodsEnum']) -> tuple[HttpMethod, ...]:
         """HTTP methods that have a body in the structure."""
         return (
             cls.GET.value,
@@ -27,7 +27,7 @@ class HttpMethodsEnum(enum.Enum):
         )
 
     @classmethod
-    def get_methods_with_body(cls: type['HttpMethodsEnum']) -> tuple[HttpMethod, HttpMethod, HttpMethod]:
+    def get_methods_with_body(cls: type['HttpMethodsEnum']) -> tuple[HttpMethod, ...]:
         """HTTP methods that do not have a body in the structure."""
         return (
             cls.POST.value,

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,7 +3,7 @@ select = WPS
 format = wemake
 show-source = False
 statistics = False
-known-enum-bases= CommandsEnum
+known-enum-bases= CurlCommandsEnum
 per-file-ignores =
     ./curlifier/__init__.py:  WPS412, WPS410
     ./curlifier/__version__.py: WPS101

--- a/tests/builders/test_configurator.py
+++ b/tests/builders/test_configurator.py
@@ -9,14 +9,14 @@ from curlifier.structures.commands import CommandsConfigureEnum
 @pytest.mark.parametrize('silent', [True, False])
 @pytest.mark.parametrize('insecure', [True, False])
 @pytest.mark.parametrize('include', [True, False])
-@pytest.mark.parametrize('build_short', [True, False])
+@pytest.mark.parametrize('shorted', [True, False])
 def test_config_builder(
     location,
     verbose,
     silent,
     insecure,
     include,
-    build_short,
+    shorted,
 ):
     builder = ConfigBuilder(
         location=location,
@@ -24,31 +24,31 @@ def test_config_builder(
         silent=silent,
         insecure=insecure,
         include=include,
-        build_short=build_short,
+        shorted=shorted,
     )
     built: str = builder.build()
 
     if location:
-        assert CommandsConfigureEnum.LOCATION.get(shorted=build_short) in built
+        assert CommandsConfigureEnum.LOCATION.get(shorted=shorted) in built
     else:
-        assert CommandsConfigureEnum.LOCATION.get(shorted=build_short) not in built
+        assert CommandsConfigureEnum.LOCATION.get(shorted=shorted) not in built
 
     if verbose:
-        assert CommandsConfigureEnum.VERBOSE.get(shorted=build_short) in built
+        assert CommandsConfigureEnum.VERBOSE.get(shorted=shorted) in built
     else:
-        assert CommandsConfigureEnum.VERBOSE.get(shorted=build_short) not in built
+        assert CommandsConfigureEnum.VERBOSE.get(shorted=shorted) not in built
 
     if silent:
-        assert CommandsConfigureEnum.SILENT.get(shorted=build_short) in built
+        assert CommandsConfigureEnum.SILENT.get(shorted=shorted) in built
     else:
-        assert CommandsConfigureEnum.SILENT.get(shorted=build_short) not in built
+        assert CommandsConfigureEnum.SILENT.get(shorted=shorted) not in built
 
     if insecure:
-        assert CommandsConfigureEnum.INSECURE.get(shorted=build_short) in built
+        assert CommandsConfigureEnum.INSECURE.get(shorted=shorted) in built
     else:
-        assert CommandsConfigureEnum.INSECURE.get(shorted=build_short) not in built
+        assert CommandsConfigureEnum.INSECURE.get(shorted=shorted) not in built
 
     if include:
-        assert CommandsConfigureEnum.INCLUDE.get(shorted=build_short) in built
+        assert CommandsConfigureEnum.INCLUDE.get(shorted=shorted) in built
     else:
-        assert CommandsConfigureEnum.INCLUDE.get(shorted=build_short) not in built
+        assert CommandsConfigureEnum.INCLUDE.get(shorted=shorted) not in built

--- a/tests/builders/test_curl.py
+++ b/tests/builders/test_curl.py
@@ -16,7 +16,7 @@ from curlifier.structures.http_methods import HttpMethodsEnum
 @pytest.mark.parametrize('insecure', [True, False])
 @pytest.mark.parametrize('include', [True, False])
 @pytest.mark.parametrize('http_method_w_body', list(HttpMethodsEnum.get_methods_with_body()))
-@pytest.mark.parametrize('build_short', [True, False])
+@pytest.mark.parametrize('shorted', [True, False])
 class TestCurlWithBody:
     def test_request_w_files(
         self,
@@ -24,7 +24,7 @@ class TestCurlWithBody:
         mock_response,
         fake_url,
         files,
-        build_short,
+        shorted,
         transmitter_builder_w_files_payload,
         location,
         verbose,
@@ -36,7 +36,7 @@ class TestCurlWithBody:
             response = requests.request(http_method_w_body, url=fake_url, files=files)
         curl = CurlBuilder(
             response=response,
-            build_short=build_short,
+            shorted=shorted,
             location=location,
             verbose=verbose,
             silent=silent,
@@ -44,24 +44,24 @@ class TestCurlWithBody:
             include=include,
         )
         built = curl.build()
-        assert transmitter_builder_w_files_payload(build_short, http_method_w_body, fake_url) in built
+        assert transmitter_builder_w_files_payload(shorted, http_method_w_body, fake_url) in built
         if location:
-            assert CommandsConfigureEnum.LOCATION.get(shorted=build_short) in built
+            assert CommandsConfigureEnum.LOCATION.get(shorted=shorted) in built
         if verbose:
-            assert CommandsConfigureEnum.VERBOSE.get(shorted=build_short) in built
+            assert CommandsConfigureEnum.VERBOSE.get(shorted=shorted) in built
         if silent:
-            assert CommandsConfigureEnum.SILENT.get(shorted=build_short) in built
+            assert CommandsConfigureEnum.SILENT.get(shorted=shorted) in built
         if insecure:
-            assert CommandsConfigureEnum.INSECURE.get(shorted=build_short) in built
+            assert CommandsConfigureEnum.INSECURE.get(shorted=shorted) in built
         if include:
-            assert CommandsConfigureEnum.INCLUDE.get(shorted=build_short) in built
+            assert CommandsConfigureEnum.INCLUDE.get(shorted=shorted) in built
 
     def test_request_w_json(
         self,
         http_method_w_body,
         mock_response,
         fake_url,
-        build_short,
+        shorted,
         fake_json_like_dict,
         transmitter_builder_w_json_payload,
         location,
@@ -74,18 +74,18 @@ class TestCurlWithBody:
             response = requests.request(http_method_w_body, url=fake_url, json=fake_json_like_dict)
         curl = CurlBuilder(
             response=response,
-            build_short=build_short,
+            shorted=shorted,
             location=location,
             verbose=verbose,
             silent=silent,
             insecure=insecure,
             include=include,
         )
-        assert build_short == curl.build_short
+        assert shorted == curl.shorted
         built = curl.build()
         assert (
             transmitter_builder_w_json_payload(
-                build_short,
+                shorted,
                 http_method_w_body,
                 fake_url,
                 json.dumps(fake_json_like_dict),
@@ -94,22 +94,22 @@ class TestCurlWithBody:
         )
 
         if location:
-            assert CommandsConfigureEnum.LOCATION.get(shorted=build_short) in built
+            assert CommandsConfigureEnum.LOCATION.get(shorted=shorted) in built
         if verbose:
-            assert CommandsConfigureEnum.VERBOSE.get(shorted=build_short) in built
+            assert CommandsConfigureEnum.VERBOSE.get(shorted=shorted) in built
         if silent:
-            assert CommandsConfigureEnum.SILENT.get(shorted=build_short) in built
+            assert CommandsConfigureEnum.SILENT.get(shorted=shorted) in built
         if insecure:
-            assert CommandsConfigureEnum.INSECURE.get(shorted=build_short) in built
+            assert CommandsConfigureEnum.INSECURE.get(shorted=shorted) in built
         if include:
-            assert CommandsConfigureEnum.INCLUDE.get(shorted=build_short) in built
+            assert CommandsConfigureEnum.INCLUDE.get(shorted=shorted) in built
 
     def test_request_w_data(
         self,
         http_method_w_body,
         mock_response,
         fake_url,
-        build_short,
+        shorted,
         fake_xml,
         transmitter_builder_w_xml_payload,
         location,
@@ -122,7 +122,7 @@ class TestCurlWithBody:
             response = requests.request(http_method_w_body, url=fake_url, data=fake_xml)
         curl = CurlBuilder(
             response=response,
-            build_short=build_short,
+            shorted=shorted,
             location=location,
             verbose=verbose,
             silent=silent,
@@ -132,7 +132,7 @@ class TestCurlWithBody:
         built = curl.build()
         assert (
             transmitter_builder_w_xml_payload(
-                build_short,
+                shorted,
                 http_method_w_body,
                 fake_url,
                 fake_xml,
@@ -141,15 +141,15 @@ class TestCurlWithBody:
         )
 
         if location:
-            assert CommandsConfigureEnum.LOCATION.get(shorted=build_short) in built
+            assert CommandsConfigureEnum.LOCATION.get(shorted=shorted) in built
         if verbose:
-            assert CommandsConfigureEnum.VERBOSE.get(shorted=build_short) in built
+            assert CommandsConfigureEnum.VERBOSE.get(shorted=shorted) in built
         if silent:
-            assert CommandsConfigureEnum.SILENT.get(shorted=build_short) in built
+            assert CommandsConfigureEnum.SILENT.get(shorted=shorted) in built
         if insecure:
-            assert CommandsConfigureEnum.INSECURE.get(shorted=build_short) in built
+            assert CommandsConfigureEnum.INSECURE.get(shorted=shorted) in built
         if include:
-            assert CommandsConfigureEnum.INCLUDE.get(shorted=build_short) in built
+            assert CommandsConfigureEnum.INCLUDE.get(shorted=shorted) in built
 
 
 @pytest.mark.parametrize('location', [True, False])
@@ -157,7 +157,7 @@ class TestCurlWithBody:
 @pytest.mark.parametrize('silent', [True, False])
 @pytest.mark.parametrize('insecure', [True, False])
 @pytest.mark.parametrize('include', [True, False])
-@pytest.mark.parametrize('build_short', [True, False])
+@pytest.mark.parametrize('shorted', [True, False])
 @pytest.mark.parametrize(
     'http_method_without_body',
     list(HttpMethodsEnum.get_methods_without_body()),
@@ -167,7 +167,7 @@ class TestCurlWithOutBody:
         self,
         mock_response,
         fake_url,
-        build_short,
+        shorted,
         http_method_without_body,
         transmitter_builder_without_body_payload,
         location,
@@ -180,7 +180,7 @@ class TestCurlWithOutBody:
             response = requests.request(http_method_without_body, url=fake_url)
         curl = CurlBuilder(
             response=response,
-            build_short=build_short,
+            shorted=shorted,
             location=location,
             verbose=verbose,
             silent=silent,
@@ -190,7 +190,7 @@ class TestCurlWithOutBody:
         built = curl.build()
         assert (
             transmitter_builder_without_body_payload(
-                build_short,
+                shorted,
                 http_method_without_body,
                 fake_url,
             )
@@ -198,12 +198,12 @@ class TestCurlWithOutBody:
         )
 
         if location:
-            assert CommandsConfigureEnum.LOCATION.get(shorted=build_short) in built
+            assert CommandsConfigureEnum.LOCATION.get(shorted=shorted) in built
         if verbose:
-            assert CommandsConfigureEnum.VERBOSE.get(shorted=build_short) in built
+            assert CommandsConfigureEnum.VERBOSE.get(shorted=shorted) in built
         if silent:
-            assert CommandsConfigureEnum.SILENT.get(shorted=build_short) in built
+            assert CommandsConfigureEnum.SILENT.get(shorted=shorted) in built
         if insecure:
-            assert CommandsConfigureEnum.INSECURE.get(shorted=build_short) in built
+            assert CommandsConfigureEnum.INSECURE.get(shorted=shorted) in built
         if include:
-            assert CommandsConfigureEnum.INCLUDE.get(shorted=build_short) in built
+            assert CommandsConfigureEnum.INCLUDE.get(shorted=shorted) in built

--- a/tests/builders/test_transmitter.py
+++ b/tests/builders/test_transmitter.py
@@ -72,7 +72,7 @@ class TestPreparedTransmitterWithOutBody(PreparedTransmitterTest):
 
 
 @pytest.mark.parametrize('http_method_w_body', list(HttpMethodsEnum.get_methods_with_body()))
-@pytest.mark.parametrize('build_short', [True, False])
+@pytest.mark.parametrize('shorted', [True, False])
 class TestTransmitterBuilderWithBody:
     def test_request_w_files(
         self,
@@ -80,30 +80,30 @@ class TestTransmitterBuilderWithBody:
         mock_response,
         fake_url,
         files,
-        build_short,
+        shorted,
         transmitter_builder_w_files_payload,
     ):
         with mock_response:
             response = requests.request(http_method_w_body, url=fake_url, files=files)
-        transmitter_builder = TransmitterBuilder(response=response, build_short=build_short)
+        transmitter_builder = TransmitterBuilder(response=response, shorted=shorted)
         built = transmitter_builder.build()
-        assert built == transmitter_builder_w_files_payload(build_short, http_method_w_body, fake_url)
+        assert built == transmitter_builder_w_files_payload(shorted, http_method_w_body, fake_url)
 
     def test_request_w_json(
         self,
         http_method_w_body,
         mock_response,
         fake_url,
-        build_short,
+        shorted,
         fake_json_like_dict,
         transmitter_builder_w_json_payload,
     ):
         with mock_response:
             response = requests.request(http_method_w_body, url=fake_url, json=fake_json_like_dict)
-        transmitter_builder = TransmitterBuilder(response=response, build_short=build_short)
+        transmitter_builder = TransmitterBuilder(response=response, shorted=shorted)
         built = transmitter_builder.build()
         assert built == transmitter_builder_w_json_payload(
-            build_short,
+            shorted,
             http_method_w_body,
             fake_url,
             json.dumps(fake_json_like_dict),
@@ -114,16 +114,16 @@ class TestTransmitterBuilderWithBody:
         http_method_w_body,
         mock_response,
         fake_url,
-        build_short,
+        shorted,
         fake_xml,
         transmitter_builder_w_xml_payload,
     ):
         with mock_response:
             response = requests.request(http_method_w_body, url=fake_url, data=fake_xml)
-        transmitter_builder = TransmitterBuilder(response=response, build_short=build_short)
+        transmitter_builder = TransmitterBuilder(response=response, shorted=shorted)
         built = transmitter_builder.build()
         assert built == transmitter_builder_w_xml_payload(
-            build_short,
+            shorted,
             http_method_w_body,
             fake_url,
             fake_xml,
@@ -134,22 +134,22 @@ class TestTransmitterBuilderWithBody:
     'http_method_without_body',
     list(HttpMethodsEnum.get_methods_without_body()),
 )
-@pytest.mark.parametrize('build_short', [True, False])
+@pytest.mark.parametrize('shorted', [True, False])
 class TestTransmitterBuilderWithOutBody:
     def test_request_without_body(
         self,
         mock_response,
         fake_url,
-        build_short,
+        shorted,
         http_method_without_body,
         transmitter_builder_without_body_payload,
     ):
         with mock_response:
             response = requests.request(http_method_without_body, url=fake_url)
-        transmitter_builder = TransmitterBuilder(response=response, build_short=build_short)
+        transmitter_builder = TransmitterBuilder(response=response, shorted=shorted)
         built = transmitter_builder.build()
         assert built == transmitter_builder_without_body_payload(
-            build_short,
+            shorted,
             http_method_without_body,
             fake_url,
         )

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -7,10 +7,10 @@ from curlifier import curlify
 from curlifier.structures.http_methods import HttpMethodsEnum
 
 
-@pytest.mark.parametrize('build_short', [True, False])
-def test_curlify_happy_path(fake_url, mock_response, fake_json_like_dict, build_short, curlify_hp_curl):
+@pytest.mark.parametrize('shorted', [True, False])
+def test_curlify_happy_path(fake_url, mock_response, fake_json_like_dict, shorted, curlify_hp_curl):
     with mock_response:
         response = requests.request(HttpMethodsEnum.POST.value, url=fake_url, json=fake_json_like_dict)
-    curl = curlify(response, shorted=build_short, location=True)
+    curl = curlify(response, shorted=shorted, location=True)
 
-    assert curl == curlify_hp_curl(build_short, fake_url, json.dumps(fake_json_like_dict))
+    assert curl == curlify_hp_curl(shorted, fake_url, json.dumps(fake_json_like_dict))

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -14,3 +14,13 @@ def test_curlify_happy_path(fake_url, mock_response, fake_json_like_dict, shorte
     curl = curlify(response, shorted=shorted, location=True)
 
     assert curl == curlify_hp_curl(shorted, fake_url, json.dumps(fake_json_like_dict))
+
+
+@pytest.mark.parametrize('shorted', [True, False])
+def test_curlify_happy_path_w_pre_req(fake_url, mock_response, fake_json_like_dict, shorted, curlify_hp_curl):
+    with mock_response:
+        response = requests.request(HttpMethodsEnum.POST.value, url=fake_url, json=fake_json_like_dict)
+        pre_req = response.request
+    curl = curlify(prepared_request=pre_req, shorted=shorted, location=True)
+
+    assert curl == curlify_hp_curl(shorted, fake_url, json.dumps(fake_json_like_dict))


### PR DESCRIPTION
**Added:**
- New test case for `curlify` function with `prepared_request` parameter
- `.PHONY` targets in Makefile for better build system organization
- `__slots__` definitions for better memory optimization in `Decoder`, `PreparedTransmitter`, and `TransmitterBuilder` classes
- `cspell` target in Makefile for spell checking

**Changed:**
- Renamed `build_short` parameter to `shorted` across all classes and functions for better naming consistency
- Updated `CommandsEnum` class name to `CurlCommandsEnum` for clearer naming
- Improved `CurlBuilder` constructor to use `**config` parameter unpacking instead of individual boolean parameters
- Enhanced type hints for HTTP methods return types using `tuple[HttpMethod, ...]`
- Updated all test cases to use the new `shorted` parameter name
- Fixed typo in Makefile comment from "Сonfiguration" to "Configuration"

**Removed:**
- Redundant intermediate variable assignment in `curlify` function
- Individual boolean parameters from `CurlBuilder` constructor in favor of `**config` unpacking